### PR TITLE
[ticket/14458] Explicitly state RewriteBase into .htaccess root file

### DIFF
--- a/phpBB/.htaccess
+++ b/phpBB/.htaccess
@@ -2,6 +2,16 @@
 RewriteEngine on
 
 #
+# Uncomment the statement below if URL rewriting doesn't
+# work properly. If you installed phpBB in a subdirectory
+# of your site, properly set the argument for the statement.
+# e.g.: if your domain is test.com and you installed phpBB
+# in http://www.test.com/phpBB/index.php you have to set
+# the statement RewriteBase /phpBB/
+#
+#RewriteBase /
+
+#
 # Uncomment the statement below if you want to make use of
 # HTTP authentication and it does not already work.
 # This could be required if you are for example using PHP via Apache CGI.


### PR DESCRIPTION
The statement `RewriteBase /` needs to be explicitly typed down into the .htaccess file in root in order to reduce all the support requests about the implicit statement and the URL rewriting not working.

[PHPBB3-1445](https://tracker.phpbb.com/browse/PHPBB3-14458)